### PR TITLE
Add log-level to input

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Copy [your Okteto API token](https://www.okteto.com/docs/cloud/personal-access-t
 
 **Required** Your Okteto instance URL.
 
+### `log-level`
+
+Log level used. Supported values are: `debug`, `info`, `warn`, `error`. (defaults to warn)
+
+
 ## Example usage
 
 This example runs the context action and then activates a namespace.

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   namespace: 
     description: "If present, the namespace you want to point to. If not specified, it will use the default namespace."
     required: false
+  log-level:
+    description: "Log level string. Valid options are debug, info, warn, error"
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -17,6 +20,7 @@ runs:
     - ${{ inputs.token }}
     - ${{ inputs.url }}
     - ${{ inputs.namespace }}
+    - ${{ inputs.log-level }}
 branding:
   color: 'green'
   icon: 'at-sign'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,7 @@ if [ ! -z "$log_level" ]; then
   if [ "$log_level" = "debug" ] || [ "$log_level" = "info" ] || [ "$log_level" = "warn" ] || [ "$log_level" = "error" ] ; then
     log_level="--log-level ${log_level}"
   else
-    echo "log-level supported: debug, info, warn, error"
+    echo "unsupported log-level ${log_level}, supported options are: debug, info, warn, error"
     exit 1
   fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,8 +21,25 @@ if [ ! -z $namespace ]; then
   args="--namespace=$namespace"
 fi
 
-echo running: okteto context use --token=$token $args $url
-okteto context use --token=$token $args $url 
+log_level=$4
+if [ ! -z "$log_level" ]; then
+  if [ "$log_level" = "debug" ] || [ "$log_level" = "info" ] || [ "$log_level" = "warn" ] || [ "$log_level" = "error" ] ; then
+    log_level="--log-level ${log_level}"
+  else
+    echo "log-level supported: debug, info, warn, error"
+    exit 1
+  fi
+fi
+
+# https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging
+# https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+if [ "${RUNNER_DEBUG}" = "1" ]; then
+  log_level="--log-level debug"
+fi
+
+
+echo running: okteto context use --token=$token $args $url $log_level
+okteto context use --token=$token $args $url $log_level
 
 echo running: okteto kubeconfig
 eval okteto kubeconfig


### PR DESCRIPTION
Resolves https://okteto.atlassian.net/browse/DEV-320

As done for `deploy-preview` this PR adds the input of log-level to the action in order to enable debug logging or any other level the user wants to use on the runs.

Tested running the pipeline using the last commit 
https://github.com/teresaromero/go-getting-started/actions/workflows/test-actions.yml